### PR TITLE
Changes assignment of 'Notes' from 0 to NaN in densimeters.py.

### DIFF
--- a/src/DiadFit/densimeters.py
+++ b/src/DiadFit/densimeters.py
@@ -116,7 +116,7 @@ def calculate_density_cornell_old(*, temp='SupCrit', Split, split_err=None):
     Too_Low_RT=df['Corrected_Splitting']<102.734115670188
 
     df.loc[zero, 'Preferred D']=0
-    df.loc[zero, 'Notes']=0
+    df.loc[zero, 'Notes']=pd.NA
 
 
     # If room T, low density, set as low density
@@ -655,7 +655,7 @@ CI_split=0.67, CI_neon=0.67,  Ne_pickle_str=None, pref_Ne=None, Ne_err=None, cor
     Too_Low_RT=df['Corrected_Splitting']<102.734115670188
 
     df.loc[zero, 'Preferred D']=0
-    df.loc[zero, 'Notes']=0
+    df.loc[zero, 'Notes']=pd.NA
     
     # Get rid of pandas 2 issue with warning of setting item of incompatible dtype
     df['Preferred D'] = df['Preferred D'].astype('float64', errors='ignore')

--- a/src/DiadFit/densimeters.py
+++ b/src/DiadFit/densimeters.py
@@ -1242,7 +1242,7 @@ CI_split=0.67, CI_neon=0.67,  Ne_pickle_str=None, Ar_pickle_str=None, pref_Ne=No
     # Impossible densities, room T
     Imposs_upper_end=(df['Corrected_Splitting']<105.3438707618937+offset)# & (df['Splitting']>103.88+offset)  
     df.loc[zero, 'Preferred D']=0
-    df.loc[zero, 'Notes']=0
+    df.loc[zero, 'Notes']=pd.NA
     
     # Assign to the right type to avoid annoying pandas 2 warning
     # Ensure the columns are of type float64

--- a/src/DiadFit/diads.py
+++ b/src/DiadFit/diads.py
@@ -4259,8 +4259,8 @@ def plot_secondary_peaks(*, Diad_Files, path, filetype,
             if len(df_peak_sort>=1):
 
                 df_peak_sort_short=df_peak_sort[0:1]
-                peak_pos_saved[i]=df_peak_sort_short['pos'].values
-                peak_height_saved[i]=df_peak_sort_short['height'].values
+                peak_pos_saved[i]=df_peak_sort_short['pos'].values[0]
+                peak_height_saved[i]=df_peak_sort_short['height'].values[0]
             else:
 
                 peak_pos_saved[i]=np.nan


### PR DESCRIPTION
Changes assignment to 'Notes' from 0 to NaN. Was causing invalid value error in notebook Step 4 at cell [12]: 
df=pf.calculate_density_ucb(df_combo=df_combo_sec_phase,
  Ne_pickle_str='Neon_corr_model.pkl',  temp='SupCrit', CI_split=0.67, CI_neon=0.67)
df.head()

If not NaN, replace with something else, like a str (could be "0", if the 0 is important later). 'Notes' is a string column that won't accept integer as assignment. 

Error traceback below....

TypeError                                 Traceback (most recent call last)
Cell In[42], line 1
----> 1 df=pf.calculate_density_ucb(df_combo=df_combo_sec_phase,
      2   Ne_pickle_str='Neon_corr_model.pkl',  temp='SupCrit', CI_split=0.67, CI_neon=0.67)
      3 df.head()

File /opt/anaconda3/envs/thermoengine_env/lib/python3.12/site-packages/DiadFit/densimeters.py:1245, in calculate_density_ucb(Ne_line_combo, df_combo, temp, CI_split, CI_neon, Ne_pickle_str, Ar_pickle_str, pref_Ne, Ne_err, corrected_split, split_err)
   1243 Imposs_upper_end=(df['Corrected_Splitting']<105.3438707618937+offset)# & (df['Splitting']>103.88+offset)  
   1244 df.loc[zero, 'Preferred D']=0
-> 1245 df.loc[zero, 'Notes']=0
   1247 # Assign to the right type to avoid annoying pandas 2 warning
   1248 # Ensure the columns are of type float64
   1249 df['Preferred D'] = df['Preferred D'].astype('float64', errors='ignore')

File /opt/anaconda3/envs/thermoengine_env/lib/python3.12/site-packages/pandas/core/indexing.py:938, in _LocationIndexer.__setitem__(self, key, value)
    933 self._has_valid_setitem_indexer(key)
    935 iloc: _iLocIndexer = (
    936     cast("_iLocIndexer", self) if self.name == "iloc" else self.obj.iloc
    937 )
--> 938 iloc._setitem_with_indexer(indexer, value, self.name)

File /opt/anaconda3/envs/thermoengine_env/lib/python3.12/site-packages/pandas/core/indexing.py:1953, in _iLocIndexer._setitem_with_indexer(self, indexer, value, name)
   1950 # align and set the values
   1951 if take_split_path:
   1952     # We have to operate column-wise
-> 1953     self._setitem_with_indexer_split_path(indexer, value, name)
   1954 else:
   1955     self._setitem_single_block(indexer, value, name)

File /opt/anaconda3/envs/thermoengine_env/lib/python3.12/site-packages/pandas/core/indexing.py:2044, in _iLocIndexer._setitem_with_indexer_split_path(self, indexer, value, name)
   2041 else:
   2042     # scalar value
   2043     for loc in ilocs:
-> 2044         self._setitem_single_column(loc, value, pi)

File /opt/anaconda3/envs/thermoengine_env/lib/python3.12/site-packages/pandas/core/indexing.py:2181, in _iLocIndexer._setitem_single_column(self, loc, value, plane_indexer)
   2171 if dtype == np.void:
   2172     # This means we're expanding, with multiple columns, e.g.
   2173     #     df = pd.DataFrame({'A': [1,2,3], 'B': [4,5,6]})
   (...)   2176     # Here, we replace those temporary `np.void` columns with
   2177     # columns of the appropriate dtype, based on `value`.
   2178     self.obj.iloc[:, loc] = construct_1d_array_from_inferred_fill_value(
   2179         value, len(self.obj)
   2180     )
-> 2181 self.obj._mgr.column_setitem(loc, plane_indexer, value)

File /opt/anaconda3/envs/thermoengine_env/lib/python3.12/site-packages/pandas/core/internals/managers.py:1520, in BlockManager.column_setitem(self, loc, idx, value, inplace_only)
   1518     col_mgr.setitem_inplace(idx, value)
   1519 else:
-> 1520     new_mgr = col_mgr.setitem((idx,), value)
   1521     self.iset(loc, new_mgr._block.values, inplace=True)

File /opt/anaconda3/envs/thermoengine_env/lib/python3.12/site-packages/pandas/core/internals/managers.py:604, in BaseBlockManager.setitem(self, indexer, value)
    600     # No need to split if we either set all columns or on a single block
    601     # manager
    602     self = self.copy(deep=True)
--> 604 return self.apply("setitem", indexer=indexer, value=value)

File /opt/anaconda3/envs/thermoengine_env/lib/python3.12/site-packages/pandas/core/internals/managers.py:442, in BaseBlockManager.apply(self, f, align_keys, **kwargs)
    440         applied = b.apply(f, **kwargs)
    441     else:
--> 442         applied = getattr(b, f)(**kwargs)
    443     result_blocks = extend_blocks(applied, result_blocks)
    445 out = type(self).from_blocks(result_blocks, [ax.view() for ax in self.axes])

File /opt/anaconda3/envs/thermoengine_env/lib/python3.12/site-packages/pandas/core/internals/blocks.py:1667, in EABackedBlock.setitem(self, indexer, value)
   1664 check_setitem_lengths(indexer, value, values)
   1666 try:
-> 1667     values[indexer] = value
   1668 except (ValueError, TypeError):
   1669     if isinstance(self.dtype, IntervalDtype):
   1670         # see TestSetitemFloatIntervalWithIntIntervalValues

File /opt/anaconda3/envs/thermoengine_env/lib/python3.12/site-packages/pandas/core/arrays/string_.py:863, in StringArray.__setitem__(self, key, value)
    860 if self._readonly:
    861     raise ValueError("Cannot modify read-only array")
--> 863 value = self._maybe_convert_setitem_value(value)
    865 key = check_array_indexer(self, key)
    866 scalar_key = lib.is_scalar(key)

File /opt/anaconda3/envs/thermoengine_env/lib/python3.12/site-packages/pandas/core/arrays/string_.py:837, in StringArray._maybe_convert_setitem_value(self, value)
    835         value = self.dtype.na_value
    836     elif not isinstance(value, str):
--> 837         raise TypeError(
    838             f"Invalid value '{value}' for dtype '{self.dtype}'. Value should "
    839             f"be a string or missing value, got '{type(value).__name__}' "
    840             "instead."
    841         )
    842 else:
    843     value = extract_array(value, extract_numpy=True)

TypeError: Invalid value '0' for dtype 'str'. Value should be a string or missing value, got 'int' instead.